### PR TITLE
Update package to use 1.0 APIs and has links to new docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-ascii-art
-=========
+# ascii-art package
 
 Convert selected text to ascii art banner
 
-This is the source code for the [create your own package](https://atom.io/docs/latest/your-first-package) tutorial.
+This is the source code for the [create your own package](https://atom.io/docs/latest/hacking-atom-package-modifying-text) tutorial.

--- a/keymaps/ascii-art.cson
+++ b/keymaps/ascii-art.cson
@@ -6,6 +6,6 @@
 # the root workspace element.
 
 # For more detailed documentation see
-# https://www.atom.io/docs/latest/advanced/keymaps
-'.editor':
-  'cmd-alt-a': 'ascii-art:convert'
+# https://atom.io/docs/latest/behind-atom-keymaps-in-depth
+'atom-text-editor':
+  'ctrl-alt-a': 'ascii-art:convert'

--- a/lib/ascii-art.coffee
+++ b/lib/ascii-art.coffee
@@ -16,7 +16,7 @@ module.exports =
       selection = editor.getSelectedText()
 
       figlet = require 'figlet'
-      font = "Larry 3D 2"
+      font = "o8"
       figlet selection, {font: font}, (error, art) ->
         if error
           console.error(error)

--- a/lib/ascii-art.coffee
+++ b/lib/ascii-art.coffee
@@ -1,14 +1,24 @@
-module.exports =
+{CompositeDisposable} = require 'atom'
+
+module.exports = AsciiArt =
+  subscriptions: null
+
   activate: ->
-    atom.workspaceView.command "ascii-art:convert", => @convert()
+    @subscriptions = new CompositeDisposable
+    @subscriptions.add atom.commands.add 'atom-workspace',
+      'ascii-art:convert': => @convert()
+
+  deactivate: ->
+    @subscriptions.dispose()
 
   convert: ->
-    # This assumes the active pane item is an editor
-    selection = atom.workspace.getActiveEditor().getSelection()
+    if editor = atom.workspace.getActiveTextEditor()
+      selection = editor.getSelectedText()
 
-    figlet = require 'figlet'
-    figlet selection.getText(), {font: "Larry 3D 2"}, (error, asciiArt) ->
-      if error
-        console.error(error)
-      else
-        selection.insertText("\n" + asciiArt + "\n")
+      figlet = require 'figlet'
+      font = "Larry 3D 2"
+      figlet selection, {font: font}, (error, art) ->
+        if error
+          console.error(error)
+        else
+          editor.insertText("\n#{art}\n")

--- a/lib/ascii-art.coffee
+++ b/lib/ascii-art.coffee
@@ -1,6 +1,6 @@
 {CompositeDisposable} = require 'atom'
 
-module.exports = AsciiArt =
+module.exports =
   subscriptions: null
 
   activate: ->

--- a/package.json
+++ b/package.json
@@ -2,15 +2,16 @@
   "name": "ascii-art",
   "main": "./lib/ascii-art",
   "version": "0.0.0",
-  "private": true,
   "description": "A short description of your package",
-  "activationEvents": ["ascii-art:convert"],
+  "activationCommands": {
+    "atom-workspace": "ascii-art:convert"
+  },
   "repository": "https://github.com/atom/ascii-art",
   "license": "MIT",
   "engines": {
-    "atom": ">0.39.0"
+    "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-     "figlet": "1.0.8"
+   "figlet": "1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-   "figlet": "1.0.8"
+    "figlet": "1.0.8"
   }
 }

--- a/spec/ascii-art-spec.coffee
+++ b/spec/ascii-art-spec.coffee
@@ -16,7 +16,19 @@ describe "AsciiArt", ->
       atom.workspace.open()
 
   it "converts", ->
+    editor = atom.workspace.getActiveTextEditor()
+    editor.insertText("yo")
+    editor.selectAll()
+    changeHandler = jasmine.createSpy('changeHandler')
+    editor.onDidChange(changeHandler)
+
     atom.commands.dispatch workspaceElement, 'ascii-art:convert'
 
     waitsForPromise ->
       activationPromise
+
+    waitsFor ->
+      changeHandler.callCount > 0
+
+    runs ->
+      expect(editor.getText()).toEqual "\n                 \n                 \n __  __    ___   \n/\\ \\/\\ \\  / __`\\ \n\\ \\ \\_\\ \\/\\ \\L\\ \\\n \\/`____ \\ \\____/\n  `/___/> \\/___/ \n     /\\___/      \n     \\/__/       \n"

--- a/spec/ascii-art-spec.coffee
+++ b/spec/ascii-art-spec.coffee
@@ -17,7 +17,7 @@ describe "AsciiArt", ->
 
   it "converts", ->
     editor = atom.workspace.getActiveTextEditor()
-    editor.insertText("yo")
+    editor.insertText("cool")
     editor.selectAll()
     changeHandler = jasmine.createSpy('changeHandler')
     editor.onDidChange(changeHandler)
@@ -31,4 +31,13 @@ describe "AsciiArt", ->
       changeHandler.callCount > 0
 
     runs ->
-      expect(editor.getText()).toEqual "\n                 \n                 \n __  __    ___   \n/\\ \\/\\ \\  / __`\\ \n\\ \\ \\_\\ \\/\\ \\L\\ \\\n \\/`____ \\ \\____/\n  `/___/> \\/___/ \n     /\\___/      \n     \\/__/       \n"
+      expect(editor.getText()).toEqual """
+
+                                     o888  
+    ooooooo     ooooooo     ooooooo   888  
+  888     888 888     888 888     888 888  
+  888         888     888 888     888 888  
+    88ooo888    88ooo88     88ooo88  o888o 
+                                           
+
+"""

--- a/spec/ascii-art-spec.coffee
+++ b/spec/ascii-art-spec.coffee
@@ -1,4 +1,3 @@
-{WorkspaceView} = require 'atom'
 AsciiArt = require '../lib/ascii-art'
 
 # Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
@@ -7,15 +6,17 @@ AsciiArt = require '../lib/ascii-art'
 # or `fdescribe`). Remove the `f` to unfocus the block.
 
 describe "AsciiArt", ->
-  promise = null
+  [workspaceElement, activationPromise] = []
+
   beforeEach ->
-    atom.workspaceView = new WorkspaceView()
-    atom.workspace = atom.workspaceView.model
-    promise = atom.packages.activatePackage('ascii-art')
+    workspaceElement = atom.views.getView(atom.workspace)
+    activationPromise = atom.packages.activatePackage('ascii-art')
+
     waitsForPromise ->
       atom.workspace.open()
 
   it "converts", ->
-    atom.workspaceView.trigger 'ascii-art:convert'
+    atom.commands.dispatch workspaceElement, 'ascii-art:convert'
+
     waitsForPromise ->
-      promise
+      activationPromise


### PR DESCRIPTION
This updates the package so that it matches what you get when you follow the docs (so that it reduces confusion) and uses 1.0 APIs: https://atom.io/docs/latest/hacking-atom-package-modifying-text

Also tweaks a few links to the docs so that they point to the new docs site.

This is part 1 of fixing https://github.com/atom/ascii-art/issues/2, part 2 will be to tweak the new docs a bit.

cc @nathansobo @kevinsawicki 